### PR TITLE
fix: change authentication type to token

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,7 +19,7 @@ if (!secret && !process.env.GITHUB_OAUTH_KEY) {
 }
 
 octokit.authenticate({
-  type: 'oauth',
+  type: 'token',
   token: secret || process.env.GITHUB_OAUTH_KEY,
 });
 


### PR DESCRIPTION
Fix for the issue #8 
According to https://www.npmjs.com/package/@octokit/rest/v/16.9.0 the 'token' type should be used along with personal access tokens.